### PR TITLE
Redirect to https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN dnf install -y -q nginx && dnf clean all
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY run.sh /run.sh
 
-EXPOSE 80
+EXPOSE 80 443
 CMD /run.sh

--- a/nginx.conf
+++ b/nginx.conf
@@ -54,6 +54,13 @@ http {
   server {
     listen 80 default_server;
     server_name _;
+
+    return 301 https://$http_host$request_uri;
+  }
+
+  server {
+    listen 443 default_server;
+    server_name _;
     root /public;
 
     location /public {


### PR DESCRIPTION
Currently this will only work with another proxy in front of this one,
for instance an ELB. There needs to be more work done for requesting
TLS certs from vault, so that nginx can also terminate TLS.

Fixes https://github.com/UKHomeOffice/dsp/issues/2
